### PR TITLE
Implement keyboard focus navigation

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -52,6 +52,7 @@
         <script src="./js/page_parking.js"></script>
         <script src="./js/slides.js"></script>
         <script src="./js/eltovMapNavigator.js"></script>
+        <script src="./js/focus.js"></script>
         <script src="./js/app.js"></script>
     </body>
 </html>

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -154,6 +154,11 @@ const movePage = (targetPage, pageInfo = null) => {
   document.documentElement.classList.add(targetPage);
   ControlState.currentPageInfo = targetPage;
   initHtmlLanguage('page');// 언어팩에 있는 데이터로 변경
+  setTimeout(() => {
+    const el = document.querySelector(`#${targetPage} [page-tts]`);
+    if(el) el.focus();
+    document.dispatchEvent(new Event('page:changed'));
+  });
 
   //ttsPageIntro('page');
   //페이지 이동시 해당 페이지 세팅 함수 실행

--- a/src/js/focus.js
+++ b/src/js/focus.js
@@ -1,0 +1,99 @@
+(function(){
+  function isVisible(el){
+    if(!el) return false;
+    return !!(el.offsetParent !== null && window.getComputedStyle(el).display !== 'none');
+  }
+
+  function getFocusable(el){
+    const selector = 'a[href], button:not([disabled]), input:not([disabled]), textarea, select, [tabindex]:not([tabindex="-1"])';
+    return Array.from(el.querySelectorAll(selector)).filter(isVisible);
+  }
+
+  function getContext(){
+    if(window.ControlState && ControlState.currentPopupInfo){
+      const popup = document.querySelector(`#${ControlState.currentPopupInfo}.popup_layer.show`);
+      if(popup) return popup;
+    }
+    return document.querySelector(`#${ControlState.currentPageInfo}`);
+  }
+
+  function getGroups(ctx){
+    return Array.from(ctx.querySelectorAll('[focus-group]')).filter(isVisible);
+  }
+
+  function setInitialFocus(){
+    const ctx = getContext();
+    if(!ctx) return;
+    let target = ctx.querySelector('[page-tts], [popup-tts]');
+    if(target){
+      target.focus();
+      return;
+    }
+    const groups = getGroups(ctx);
+    if(groups.length){
+      const items = getFocusable(groups[0]);
+      if(items.length) items[0].focus();
+    }
+  }
+
+  function moveHorizontal(dir){
+    const ctx = getContext();
+    if(!ctx) return;
+    const groups = getGroups(ctx);
+    if(!groups.length) return;
+    const active = document.activeElement;
+    let gi = groups.findIndex(g => g.contains(active));
+    if(gi === -1){
+      setInitialFocus();
+      return;
+    }
+    const group = groups[gi];
+    const items = getFocusable(group);
+    if(!items.length) return;
+    if((dir === 1) && (active.hasAttribute('page-tts') || active.hasAttribute('popup-tts') || active.hasAttribute('group-tts'))){
+      gi = (gi + 1) % groups.length;
+      const ni = getFocusable(groups[gi]);
+      if(ni.length) ni[0].focus();
+      return;
+    }
+    let idx = items.indexOf(active);
+    if(idx === -1) idx = 0;
+    idx = (idx + dir + items.length) % items.length;
+    items[idx].focus();
+  }
+
+  function moveVertical(dir){
+    const ctx = getContext();
+    if(!ctx) return;
+    const groups = getGroups(ctx);
+    if(!groups.length) return;
+    const active = document.activeElement;
+    let gi = groups.findIndex(g => g.contains(active));
+    if(gi === -1){
+      setInitialFocus();
+      return;
+    }
+    gi = (gi + dir + groups.length) % groups.length;
+    const items = getFocusable(groups[gi]);
+    if(items.length) items[0].focus();
+  }
+
+  document.addEventListener('keydown', function(e){
+    switch(e.key){
+      case 'ArrowLeft':
+        moveHorizontal(-1); e.preventDefault(); break;
+      case 'ArrowRight':
+        moveHorizontal(1); e.preventDefault(); break;
+      case 'ArrowUp':
+        moveVertical(-1); e.preventDefault(); break;
+      case 'ArrowDown':
+        moveVertical(1); e.preventDefault(); break;
+    }
+  });
+
+  document.addEventListener('page:changed', setInitialFocus);
+  document.addEventListener('popup:opened', setInitialFocus);
+  document.addEventListener('popup:closed', setInitialFocus);
+
+  window.addEventListener('DOMContentLoaded', setInitialFocus);
+})();

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -29,7 +29,11 @@ const openPopup = async (targetPopup) => {
 
     popupWrap.classList.remove('lang_translating');
     popupWrap.classList.add('show');
-    //document.querySelector(`#layer_popup [data-tts-popup]`).focus();
+    setTimeout(() => {
+        const el = popupWrap.querySelector('[popup-tts]');
+        if(el) el.focus();
+    });
+    document.dispatchEvent(new Event('popup:opened'));
     
 };
 
@@ -43,7 +47,13 @@ function showPopup(targetPopup){
     ControlState.currentPopupInfo = targetPopup;
     initHtmlLanguage('popup');// 언어팩에 있는 데이터로 변경
 
-    document.querySelector(`#${targetPopup}`).classList.add('show');
+    const layer = document.querySelector(`#${targetPopup}`);
+    layer.classList.add('show');
+    setTimeout(() => {
+        const el = layer.querySelector('[popup-tts]');
+        if(el) el.focus();
+    });
+    document.dispatchEvent(new Event('popup:opened'));
 };
 
 const closePopup = (event, targetPopup) => {
@@ -51,6 +61,7 @@ const closePopup = (event, targetPopup) => {
     if (!event && !targetPopup) {
         const popupAll = document.querySelectorAll('.popup_layer');
         popupAll.forEach(popup => popup.classList.remove('show'));
+        document.dispatchEvent(new Event('popup:closed'));
         return
     }
     if(targetPopup){
@@ -59,6 +70,7 @@ const closePopup = (event, targetPopup) => {
         const closeLayer = event.target.closest('.popup_layer');
         closeLayer.classList.remove('show');
     }
+    document.dispatchEvent(new Event('popup:closed'));
 }
 
 

--- a/src/pages/page_map.html
+++ b/src/pages/page_map.html
@@ -1,4 +1,7 @@
 <div id="page_map" class="page_wrap">
+    <div focus-group>
+        <input type="text" page-tts>
+    </div>
     <div class="floor_info">
         <h2 id="current_floor">GF</h2>
         <h3 id="floor_info">
@@ -82,7 +85,10 @@
                 </div>
 
             </div>
-            <div class="tab_btn type1 floor_selects">
+            <div class="tab_btn type1 floor_selects" focus-group>
+                <div focus-group>
+                    <input type="text" group-tts>
+                </div>
                 <div class="item"><button type="button" class="active" data-floor="GF" data-floor-title-en="FOODIE STATION" data-floor-title-ko="푸디 스테이션" onClick="mapSelectFloor(this, 'GF')">GF</button></div>
                 <div class="item"><button type="button" data-floor="1F" data-floor-title-en="BEAUTY & TREND" data-floor-title-ko="컬처 & 매니아" onClick="mapSelectFloor(this, '1F')">1F</button></div>
                 <div class="item"><button type="button" data-floor="2F" data-floor-title-en="NEW WAVE" data-floor-title-ko="뉴 웨이브" onClick="mapSelectFloor(this, '2F')">2F</button></div>
@@ -95,7 +101,10 @@
                     </button>
                 </div>
             </div>
-            <div class="map_control">
+            <div class="map_control" focus-group>
+                <div focus-group>
+                    <input type="text" group-tts>
+                </div>
                 <button type="button" onclick="mapZoomControl('full');">
                     <svg xmlns="http://www.w3.org/2000/svg" width="101" height="101" fill="none"><path stroke="CurrentColor" stroke-miterlimit="10" stroke-width="6" d="M97.47 3.53H3V98h94.47V3.53Z"/><path stroke="CurrentColor" stroke-miterlimit="10" stroke-width="6" d="M30.858 14.155H14.851V30.182M36.64 35.939 14.85 14.155M85.619 30.229V14.221H69.587M63.83 36.005 85.62 14.221M69.611 87.376H85.62V71.349M63.83 65.592 85.62 87.376M14.85 71.302v16.007h16.032M36.64 65.525 14.85 87.31"/></svg>
                     <span data-lang-code="전체보기">전체보기</span>
@@ -112,8 +121,11 @@
         </div>
 
         <!-- 편의시설 (길찾기 전) -->
-        <div class="facility_cates">
-            <div id="pub_quick_items" class="tab_btn type2">
+        <div class="facility_cates" >
+            <div id="pub_quick_items" class="tab_btn type2" focus-group>
+                <div focus-group>
+                    <input type="text" group-tts>
+                </div>
                 <!-- <div class="item">
                     <button type="button" onClick="mapSelectCate(this, 'P11')">
                         <img>
@@ -143,7 +155,10 @@
 
         <!-- 지도 콘트롤 (길찾기 후) -->
         <div class="wayfind_control">
-            <div class="tab_btn type2">
+            <div class="tab_btn type2" focus-group>
+                <div focus-group>
+                    <input type="text" group-tts>
+                </div>
                 <div class="item">
                     <button type="button"  onclick="mapZoomControl('full');">
                         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 101 101" width="101" height="101" fill="none"><path stroke="CurrentColor" stroke-miterlimit="10" stroke-width="6" d="M97.47 3.53H3V98h94.47V3.53Z"/><path stroke="CurrentColor" stroke-miterlimit="10" stroke-width="6" d="M30.858 14.155H14.851V30.182M36.64 35.939 14.85 14.155M85.619 30.229V14.221H69.587M63.83 36.005 85.62 14.221M69.611 87.376H85.62V71.349M63.83 65.592 85.62 87.376M14.85 71.302v16.007h16.032M36.64 65.525 14.85 87.31"/></svg>

--- a/src/partials/popup.html
+++ b/src/partials/popup.html
@@ -7,7 +7,7 @@
 <!-- 팝업 - 얼랏 -->
 <template id="alert_popup">
     <div class="focus_only" focus-group>
-        <input type="text" class="focus_only" data-tts-popup>
+        <input type="text" class="focus_only" popup-tts>
     </div>
     <button type="button" class="popup_close" onclick="closePopup(event);" data-lang-code="닫기">닫기</button>
     <div class="popup_title">알림</div>
@@ -22,7 +22,7 @@
 <!-- 팝업 - 에러 -->
 <template id="error_popup">
     <div class="focus_only" focus-group>
-        <input type="text" class="focus_only" data-tts-popup>
+        <input type="text" class="focus_only" popup-tts>
     </div>
     <button type="button" class="popup_close" onclick="closePopup(event);" data-lang-code="닫기">닫기</button>
     <div class="popup_title">프린트 에러</div>
@@ -34,7 +34,7 @@
 <!-- 팝업 - 시설안내 -->
 <template id="wayfind_move_type">
     <div class="focus_only" focus-group>
-        <input type="text" class="focus_only" data-tts-popup>
+        <input type="text" class="focus_only" popup-tts>
     </div>
     <button type="button" class="popup_close" onclick="closePopup(event);" data-lang-code="닫기">닫기</button>
     <div class="popup_content center">
@@ -60,7 +60,7 @@
 <!-- 팝업 - 시설안내 -->
 <template id="facility_popup">
     <div class="focus_only" focus-group>
-        <input type="text" class="focus_only" data-tts-popup>
+        <input type="text" class="focus_only" popup-tts>
     </div>
     <button type="button" class="popup_close" onclick="closePopup(event);" data-lang-code="닫기">닫기</button>
     <div class="popup_content">
@@ -84,7 +84,7 @@
 <!-- 팝업 - 매장상세 -->
 <template id="store_popup">
     <div class="focus_only" focus-group>
-        <input type="text" class="focus_only" data-tts-popup>
+        <input type="text" class="focus_only" popup-tts>
     </div>
     <button type="button" class="popup_close" onclick="closePopup(event);" data-lang-code="닫기">닫기</button>
     <div class="popup_content">
@@ -117,7 +117,7 @@
 <!-- 팝업 - 주차 검색 결과 -->
 <template id="parking_result">
     <div class="focus_only" focus-group>
-        <input type="text" class="focus_only" data-tts-popup>
+        <input type="text" class="focus_only" popup-tts>
     </div>
     <button type="button" class="popup_close" onclick="closePopup(event);" data-lang-code="닫기">닫기</button>
     <div class="popup_content center">
@@ -165,7 +165,7 @@
         <button type="button" class="popup_close" onclick="searchCancel();" data-lang-code="닫기">닫기</button>
         <div class="popup_content">
             <div class="focus_only" focus-group>
-                <input type="text" class="focus_only" data-tts-popup>
+                <input type="text" class="focus_only" popup-tts>
             </div>
             <div class="popup_title" data-lang-code="통합검색">통합검색</div>
             @@include('../partials/keypads.html')
@@ -184,7 +184,7 @@
         <button type="button" class="popup_close" onclick="closePopup(event);" data-lang-code="닫기">닫기</button>
         <div class="popup_content">
             <div class="focus_only" focus-group>
-                <input type="text" class="focus_only" data-tts-popup>
+                <input type="text" class="focus_only" popup-tts>
             </div>
             <div class="popup_title">남은시간</div>
             <div class="time_count">
@@ -203,7 +203,7 @@
         <button type="button" class="popup_close" onclick="closePopup();" data-lang-code="닫기">닫기</button>
         <div class="popup_content">
             <div class="focus_only" focus-group>
-                <input type="text" class="focus_only" data-tts-popup>
+                <input type="text" class="focus_only" popup-tts>
             </div>
             <div class="popup_title" data-lang-code="이용방법">이용방법</div>
             @@include('../partials/parking_use.html')


### PR DESCRIPTION
## Summary
- add new focus.js script for arrow-key navigation
- focus popups and pages on open
- start page navigation from page-map
- wire popup and page events to new navigation logic

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684d80764374832d9b8770a85b049b01