### PR TITLE
Improve focus trapping

### DIFF
--- a/src/js/control.js
+++ b/src/js/control.js
@@ -37,8 +37,10 @@ function controlAction(button, type, option){
     } else if(type === 'pannel'){
         if(selectItemsStatus){
             selectItemsNext.classList.remove('active');
+            releaseFocus();
         }else{
             selectItemsNext.classList.add('active');
+            trapFocus(selectItemsNext);
             selectItemsNext.querySelector('.active').focus();
         }
     }
@@ -50,6 +52,7 @@ document.addEventListener('click', (event) => {
     if (!wrapper) {
       document.querySelectorAll('.floating .select_items')
         .forEach(item => item.classList.remove('active'));
+      releaseFocus();
     }
 });
   
@@ -66,6 +69,7 @@ function setControl(button, option, val, renderText){
     const beforeVal = ControlState[option]; //변경 전 값값
     selectItemsAll.forEach(item => item.classList.remove('active'))
     buttonAll.forEach(item => item.classList.remove('active'));
+    releaseFocus();
     
     ControlState[option] = val;
     button.classList.add('active');

--- a/src/js/focus.js
+++ b/src/js/focus.js
@@ -1,0 +1,60 @@
+// Simple focus trap utility
+let trappedEl = null;
+let lastFocusedEl = null;
+
+function getFocusableElements(container){
+  const selectors = [
+    'a[href]',
+    'area[href]',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    'button:not([disabled])',
+    'iframe',
+    'object',
+    'embed',
+    '[contenteditable]',
+    '[tabindex]:not([tabindex="-1"])'
+  ];
+  return Array.from(container.querySelectorAll(selectors.join(',')));
+}
+
+function trapFocus(container){
+  releaseFocus();
+  trappedEl = container;
+  lastFocusedEl = document.activeElement;
+  const focusable = getFocusableElements(container);
+  if(focusable.length===0) return;
+  const first = focusable[0];
+  const last = focusable[focusable.length-1];
+  function onKeydown(e){
+    if(e.key === 'Tab'){
+      if(e.shiftKey){
+        if(document.activeElement === first){
+          e.preventDefault();
+          last.focus();
+        }
+      }else{
+        if(document.activeElement === last){
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+  }
+  container.addEventListener('keydown', onKeydown);
+  container._trapHandler = onKeydown;
+}
+
+function releaseFocus(){
+  if(trappedEl){
+    trappedEl.removeEventListener('keydown', trappedEl._trapHandler);
+    delete trappedEl._trapHandler;
+    if(lastFocusedEl) lastFocusedEl.focus();
+  }
+  trappedEl = null;
+  lastFocusedEl = null;
+}
+
+window.trapFocus = trapFocus;
+window.releaseFocus = releaseFocus;

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -30,6 +30,7 @@ const openPopup = async (targetPopup) => {
 
     popupWrap.classList.remove('lang_translating');
     popupWrap.classList.add('show');
+    trapFocus(popupWrap);
     setTimeout(() => {
         const el = popupWrap.querySelector('[popup-tts]');
         if(el) el.focus();
@@ -51,6 +52,7 @@ function showPopup(targetPopup){
 
     const layer = document.querySelector(`#${targetPopup}`);
     layer.classList.add('show');
+    trapFocus(layer);
     setTimeout(() => {
         const el = layer.querySelector('[popup-tts]');
         if(el) el.focus();
@@ -63,14 +65,17 @@ const closePopup = (event, targetPopup) => {
     if (!event && !targetPopup) {
         const popupAll = document.querySelectorAll('.popup_layer');
         popupAll.forEach(popup => popup.classList.remove('show'));
+        releaseFocus();
         document.dispatchEvent(new Event('popup:closed'));
         return;
     }
     if(targetPopup){
         document.querySelector(`#${targetPopup}`).classList.remove('show');
+        releaseFocus();
     }else if(event){
         const closeLayer = event.target.closest('.popup_layer');
         closeLayer.classList.remove('show');
+        releaseFocus();
     }
     document.dispatchEvent(new Event('popup:closed'));
 }


### PR DESCRIPTION
## Summary
- manage focus loops with new trapFocus/releaseFocus helper
- trap focus in popup layer
- trap focus within accessibility setting panels

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684e632979e4832d8cea7e24efe47eec