### PR TITLE
Improve focus navigation

### DIFF
--- a/src/js/control.js
+++ b/src/js/control.js
@@ -37,8 +37,10 @@ function controlAction(button, type, option){
     } else if(type === 'pannel'){
         if(selectItemsStatus){
             selectItemsNext.classList.remove('active');
+            releaseFocus();
         }else{
             selectItemsNext.classList.add('active');
+            trapFocus(selectItemsNext);
             selectItemsNext.querySelector('.active').focus();
         }
     }
@@ -50,6 +52,7 @@ document.addEventListener('click', (event) => {
     if (!wrapper) {
       document.querySelectorAll('.floating .select_items')
         .forEach(item => item.classList.remove('active'));
+      releaseFocus();
     }
 });
   
@@ -66,6 +69,7 @@ function setControl(button, option, val, renderText){
     const beforeVal = ControlState[option]; //변경 전 값값
     selectItemsAll.forEach(item => item.classList.remove('active'))
     buttonAll.forEach(item => item.classList.remove('active'));
+    releaseFocus();
     
     ControlState[option] = val;
     button.classList.add('active');

--- a/src/js/focus.js
+++ b/src/js/focus.js
@@ -1,0 +1,191 @@
+(function(){
+  // focus trapping state
+  let trappedEl = null;
+  let lastFocusedEl = null;
+
+  function isVisible(el){
+    if(!el) return false;
+    if(el.classList.contains('focus_only')) return false;
+    const style = window.getComputedStyle(el);
+    if(style.display === 'none' || style.visibility === 'hidden') return false;
+    if(el.hasAttribute('tabindex') && el.getAttribute('tabindex') === '-1') return false;
+    if(el.offsetParent === null && style.position !== 'fixed') return false;
+    return true;
+  }
+
+  function isGroupVisible(el){
+    if(!el) return false;
+    const style = window.getComputedStyle(el);
+    if(style.display === 'none' || style.visibility === 'hidden') return false;
+    if(el.offsetParent === null && style.position !== 'fixed') return false;
+    if(el.hasAttribute('tabindex') && el.getAttribute('tabindex') === '-1') return false;
+    return true;
+  }
+
+  function getFocusable(el){
+    const selector = 'a[href], button:not([disabled]), input:not([disabled]), textarea, select, [tabindex]:not([tabindex="-1"])';
+    return Array.from(el.querySelectorAll(selector)).filter(isVisible);
+  }
+
+  function getContext(){
+    const popup = document.querySelector('.popup_layer.show');
+    if(popup) return [popup];
+    const activeSelect = document.querySelector('.floating .select_items.active');
+    if(activeSelect) return [activeSelect];
+    const contexts = [];
+    const page = document.querySelector(`#${ControlState.currentPageInfo}`);
+    if(page) contexts.push(page);
+    const floating = document.querySelector('.floating');
+    if(floating) contexts.push(floating);
+    return contexts;
+  }
+
+  function getGroups(ctxs){
+    const all = ctxs.flatMap(ctx => Array.from(ctx.querySelectorAll('[focus-group]')));
+    return all.filter(g => {
+      if(!isGroupVisible(g)) return false;
+      return !all.some(other => other !== g && other.contains(g));
+    });
+  }
+
+  function setInitialFocus(){
+    const ctxs = getContext();
+    if(!ctxs.length) return;
+    let target = null;
+    for(const c of ctxs){
+      target = c.querySelector('[page-tts], [popup-tts]');
+      if(target) break;
+    }
+    if(target){
+      target.focus();
+      return;
+    }
+    const groups = getGroups(ctxs);
+    if(groups.length){
+      const items = getFocusable(groups[0]);
+      if(items.length) items[0].focus();
+    }
+  }
+
+  function moveHorizontal(dir){
+    const ctxs = getContext();
+    if(!ctxs.length) return;
+    const groups = getGroups(ctxs);
+    if(!groups.length) return;
+    const active = document.activeElement;
+    const activeGroup = active.closest('[focus-group]');
+    let gi = groups.indexOf(activeGroup);
+    if(gi === -1){
+      setInitialFocus();
+      return;
+    }
+    const group = activeGroup;
+    const items = getFocusable(group);
+    if(!items.length) return;
+    if((dir === 1) && (active.hasAttribute('page-tts') || active.hasAttribute('popup-tts'))){
+      const nextGroup = groups[gi + 1];
+      if(nextGroup){
+        const ni = getFocusable(nextGroup);
+        if(ni.length){
+          ni[0].focus();
+        }
+      }
+      return;
+    }
+    let idx = items.indexOf(active);
+    if(idx === -1) idx = 0;
+    idx += dir;
+    if(idx < 0 || idx >= items.length) return;
+    items[idx].focus();
+  }
+
+  function moveVertical(dir){
+    const ctxs = getContext();
+    if(!ctxs.length) return;
+    const groups = getGroups(ctxs);
+    if(!groups.length) return;
+    const active = document.activeElement;
+    const activeGroup = active.closest('[focus-group]');
+    let gi = groups.indexOf(activeGroup);
+    if(gi === -1){
+      setInitialFocus();
+      return;
+    }
+    const next = groups[gi + dir];
+    if(!next) return;
+    const items = getFocusable(next);
+    if(items.length){
+      items[0].focus();
+    }
+  }
+
+  function restorePopupFocus(){
+    const el = ControlState.lastFocusBeforePopup;
+    ControlState.lastFocusBeforePopup = null;
+    if(el && document.contains(el) && isVisible(el)){
+      el.focus();
+    }else{
+      setInitialFocus();
+    }
+  }
+
+  function onKeydown(e){
+    switch(e.key){
+      case 'ArrowLeft':
+        moveHorizontal(-1); e.preventDefault(); e.stopPropagation(); break;
+      case 'ArrowRight':
+        moveHorizontal(1); e.preventDefault(); e.stopPropagation(); break;
+      case 'ArrowUp':
+        moveVertical(-1); e.preventDefault(); e.stopPropagation(); break;
+      case 'ArrowDown':
+        moveVertical(1); e.preventDefault(); e.stopPropagation(); break;
+    }
+  }
+
+  document.addEventListener('keydown', onKeydown, true);
+  document.addEventListener('page:changed', setInitialFocus);
+  document.addEventListener('popup:opened', setInitialFocus);
+  document.addEventListener('popup:closed', restorePopupFocus);
+  window.addEventListener('DOMContentLoaded', setInitialFocus);
+
+  // focus trap helpers
+  function trapFocus(container){
+    releaseFocus();
+    trappedEl = container;
+    lastFocusedEl = document.activeElement;
+    const focusable = getFocusable(container);
+    if(!focusable.length) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length-1];
+    function handle(e){
+      if(e.key === 'Tab'){
+        if(e.shiftKey){
+          if(document.activeElement === first){
+            e.preventDefault();
+            last.focus();
+          }
+        }else{
+          if(document.activeElement === last){
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    }
+    container.addEventListener('keydown', handle);
+    container._trapHandler = handle;
+  }
+
+  function releaseFocus(){
+    if(trappedEl){
+      trappedEl.removeEventListener('keydown', trappedEl._trapHandler);
+      delete trappedEl._trapHandler;
+      if(lastFocusedEl) lastFocusedEl.focus();
+    }
+    trappedEl = null;
+    lastFocusedEl = null;
+  }
+
+  window.trapFocus = trapFocus;
+  window.releaseFocus = releaseFocus;
+})();

--- a/src/js/popup.js
+++ b/src/js/popup.js
@@ -30,6 +30,7 @@ const openPopup = async (targetPopup) => {
 
     popupWrap.classList.remove('lang_translating');
     popupWrap.classList.add('show');
+    trapFocus(popupWrap);
     setTimeout(() => {
         const el = popupWrap.querySelector('[popup-tts]');
         if(el) el.focus();
@@ -51,6 +52,7 @@ function showPopup(targetPopup){
 
     const layer = document.querySelector(`#${targetPopup}`);
     layer.classList.add('show');
+    trapFocus(layer);
     setTimeout(() => {
         const el = layer.querySelector('[popup-tts]');
         if(el) el.focus();
@@ -63,14 +65,17 @@ const closePopup = (event, targetPopup) => {
     if (!event && !targetPopup) {
         const popupAll = document.querySelectorAll('.popup_layer');
         popupAll.forEach(popup => popup.classList.remove('show'));
+        releaseFocus();
         document.dispatchEvent(new Event('popup:closed'));
         return;
     }
     if(targetPopup){
         document.querySelector(`#${targetPopup}`).classList.remove('show');
+        releaseFocus();
     }else if(event){
         const closeLayer = event.target.closest('.popup_layer');
         closeLayer.classList.remove('show');
+        releaseFocus();
     }
     document.dispatchEvent(new Event('popup:closed'));
 }


### PR DESCRIPTION
## Summary
- refine visibility checks for focusable elements
- clamp arrow navigation to focus group boundaries
- allow right arrow from `page-tts`/`popup-tts` to jump to next group
- keep focus trapping for popups and settings panels

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684e632979e4832d8cea7e24efe47eec