### PR TITLE
Implement Google reCAPTCHA Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 
 
 3. 작업은 src에서 작업합니다. 터미널에서 gulp 실행시 dist 파일에 결과물이 빌드됩니다.
+
+PHP 라이브러리 의존성 관리를 위해 Composer를 사용합니다. reCAPTCHA Enterprise 기능을 사용하려면 다음 명령으로 패키지를 설치하세요.
+
+```
+composer require google/cloud-recaptcha-enterprise
+```

--- a/www/bbs/write_update.php
+++ b/www/bbs/write_update.php
@@ -2,10 +2,86 @@
 include_once('./_common.php');
 include_once(G5_LIB_PATH.'/naver_syndi.lib.php');
 include_once(G5_CAPTCHA_PATH.'/captcha.lib.php');
+include_once(G5_LIB_PATH.'/recaptcha_enterprise.lib.php');
 
 $g5['title'] = '게시글 저장';
 
 $msg = array();
+
+// Google reCAPTCHA 검증
+if (defined('RECAPTCHA_SITE_KEY') && RECAPTCHA_SITE_KEY) {
+    $recaptcha_response = isset($_POST['g-recaptcha-response']) ? trim($_POST['g-recaptcha-response']) : '';
+    if (!$recaptcha_response) {
+        alert('자동등록방지를 완료해 주세요.');
+    }
+
+    $recaptcha_ok = false;
+    if (defined('RECAPTCHA_PROJECT_ID') && RECAPTCHA_PROJECT_ID) {
+        // Use reCAPTCHA Enterprise if project ID is configured
+        $recaptcha_ok = verify_recaptcha_enterprise(
+            $recaptcha_response,
+            RECAPTCHA_SITE_KEY,
+            RECAPTCHA_PROJECT_ID,
+            defined('RECAPTCHA_EXPECTED_ACTION') ? RECAPTCHA_EXPECTED_ACTION : 'qna',
+            defined('RECAPTCHA_SCORE_THRESHOLD') ? RECAPTCHA_SCORE_THRESHOLD : 0.5
+        );
+    } else {
+        // Fallback to classic siteverify API
+        $params = http_build_query([
+            'secret'   => RECAPTCHA_SECRET_KEY,
+            'response' => $recaptcha_response,
+            'remoteip' => $_SERVER['REMOTE_ADDR'],
+        ]);
+
+        $verify = false;
+        if (ini_get('allow_url_fopen')) {
+            $context = stream_context_create([
+                'http' => [
+                    'method'  => 'POST',
+                    'header'  => "Content-Type: application/x-www-form-urlencoded\r\n",
+                    'content' => $params,
+                    'timeout' => 3,
+                ]
+            ]);
+            $verify = @file_get_contents('https://www.google.com/recaptcha/api/siteverify', false, $context);
+        }
+
+        if ($verify === false) {
+            $fp = @fsockopen('ssl://www.google.com', 443, $errno, $errstr, 5);
+            if ($fp) {
+                $out  = "POST /recaptcha/api/siteverify HTTP/1.0\r\n";
+                $out .= "Host: www.google.com\r\n";
+                $out .= "Content-Type: application/x-www-form-urlencoded\r\n";
+                $out .= "Content-Length: " . strlen($params) . "\r\n";
+                $out .= "Connection: close\r\n\r\n";
+                $out .= $params;
+
+                fwrite($fp, $out);
+                $verify = '';
+                while (!feof($fp)) {
+                    $verify .= fgets($fp, 1024);
+                }
+                fclose($fp);
+
+                $pos = strpos($verify, "\r\n\r\n");
+                if ($pos !== false) {
+                    $verify = substr($verify, $pos + 4);
+                }
+            }
+        }
+
+        if ($verify !== false && $verify !== '') {
+            $result = json_decode($verify, true);
+            if (isset($result['success']) && $result['success']) {
+                $recaptcha_ok = true;
+            }
+        }
+    }
+
+    if (!$recaptcha_ok) {
+        alert('자동등록방지 인증에 실패했습니다.');
+    }
+}
 
 $wr_subject = '';
 if (isset($_POST['wr_subject'])) {

--- a/www/config.php
+++ b/www/config.php
@@ -217,4 +217,13 @@ if(isset($_SERVER['HTTPS']) && $_SERVER['HTTPS']=='on') {   //https 통신일때
 } else {  //http 통신일때 daum 주소 js
     define('G5_POSTCODE_JS', '<script src="http://dmaps.daum.net/map_js_init/postcode.v2.js"></script>');
 }
+
+// Google reCAPTCHA 설정
+// 비밀키는 실제 발급받은 값을 사용하세요.
+define('RECAPTCHA_SITE_KEY', '6LdxdFcrAAAAAHjxHR91VnBgHqzDhkAo-ZU3hrGo');
+define('RECAPTCHA_SECRET_KEY', 'REPLACE_WITH_YOUR_SECRET');
+// reCAPTCHA Enterprise settings
+define('RECAPTCHA_PROJECT_ID', '');
+define('RECAPTCHA_EXPECTED_ACTION', 'qna');
+define('RECAPTCHA_SCORE_THRESHOLD', 0.5);
 ?>

--- a/www/lib/recaptcha_enterprise.lib.php
+++ b/www/lib/recaptcha_enterprise.lib.php
@@ -1,0 +1,59 @@
+<?php
+if (!defined('_GNUBOARD_')) exit;
+
+use Google\Cloud\RecaptchaEnterprise\V1\RecaptchaEnterpriseServiceClient;
+use Google\Cloud\RecaptchaEnterprise\V1\Event;
+use Google\Cloud\RecaptchaEnterprise\V1\Assessment;
+use Google\Cloud\RecaptchaEnterprise\V1\CreateAssessmentRequest;
+
+/**
+ * Verify reCAPTCHA Enterprise token and return risk score check result.
+ *
+ * @param string $token   The token from the client.
+ * @param string $siteKey The reCAPTCHA site key.
+ * @param string $projectId Google Cloud project ID.
+ * @param string $action  Expected action name.
+ * @param float  $threshold Minimum acceptable score. Defaults to 0.5.
+ * @return bool True if verification succeeded and score >= threshold.
+ */
+function verify_recaptcha_enterprise($token, $siteKey, $projectId, $action, $threshold = 0.5)
+{
+    if (!class_exists(RecaptchaEnterpriseServiceClient::class)) {
+        return false;
+    }
+
+    $client = new RecaptchaEnterpriseServiceClient();
+    $projectName = $client->projectName($projectId);
+
+    $event = (new Event())
+        ->setSiteKey($siteKey)
+        ->setToken($token);
+
+    $assessment = (new Assessment())
+        ->setEvent($event);
+
+    $request = (new CreateAssessmentRequest())
+        ->setParent($projectName)
+        ->setAssessment($assessment);
+
+    try {
+        $response = $client->createAssessment($request);
+
+        if (!$response->getTokenProperties()->getValid()) {
+            return false;
+        }
+
+        if ($response->getTokenProperties()->getAction() !== $action) {
+            return false;
+        }
+
+        $score = $response->getRiskAnalysis()->getScore();
+        return $score >= $threshold;
+    } catch (Exception $e) {
+        return false;
+    } finally {
+        if (method_exists($client, 'close')) {
+            $client->close();
+        }
+    }
+}

--- a/www/theme/company/mobile/skin/board/qna/write.skin.php
+++ b/www/theme/company/mobile/skin/board/qna/write.skin.php
@@ -159,7 +159,7 @@ add_stylesheet('<link rel="stylesheet" href="'.$board_skin_url.'/style.css">', 0
         <tr>
             <th scope="row">자동등록방지</th>
             <td>
-               <div class="g-recaptcha" data-sitekey="6LdxdFcrAAAAAHjxHR91VnBgHqzDhkAo-ZU3hrGo"></div>
+               <div class="g-recaptcha" data-sitekey="<?php echo RECAPTCHA_SITE_KEY; ?>" data-action="<?php echo RECAPTCHA_EXPECTED_ACTION; ?>"></div>
             </td>
         </tr>
 

--- a/www/theme/company/skin/board/qna/write.skin.php
+++ b/www/theme/company/skin/board/qna/write.skin.php
@@ -208,7 +208,7 @@ add_stylesheet('<link rel="stylesheet" href="'.$board_skin_url.'/style.css">', 0
 			<tr>
             <th scope="row">자동등록방지</th>
             <td>
-               <div class="g-recaptcha" data-sitekey="6LdxdFcrAAAAAHjxHR91VnBgHqzDhkAo-ZU3hrGo"></div>
+               <div class="g-recaptcha" data-sitekey="<?php echo RECAPTCHA_SITE_KEY; ?>" data-action="<?php echo RECAPTCHA_EXPECTED_ACTION; ?>"></div>
             </td>
         </tr>
 


### PR DESCRIPTION
## Summary
- add instructions about Composer and reCAPTCHA Enterprise
- support reCAPTCHA Enterprise verification with a new library
- call the new verification from `write_update.php`
- output the `data-action` attribute in write skins

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68739bb2f314832d9ea9e42ccc8fbaa5